### PR TITLE
Update to the current version of maven publishing plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,4 +10,4 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 [plugins]
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.29.0" }
+vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.34.0" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -52,7 +51,7 @@ android {
 }
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
 
     signAllPublications()
 


### PR DESCRIPTION


This PR updates our project to use version **0.34.0** of the `gradle-maven-publish-plugin` to address the shutdown of Sonatype's OSSRH (Open Source Software Repository Hosting) service, which was decommissioned on June 30, 2025.

## Problem
The OSSRH service, previously used for publishing to Maven Central, is no longer available, and the legacy deployment protocol is unsupported. This breaks our current publishing workflow, as the older plugin version relies on the deprecated OSSRH infrastructure.

## Solution
Starting with the version 0.33.0 and continuing with version 0.34.0 of the `gradle-maven-publish-plugin` supports publishing to the new Central Portal, which replaces OSSRH. This update ensures our artifacts can be published to Maven Central seamlessly by configuring the plugin to use the Central Portal's API and updated repository URLs. The changes include updating the plugin version in the build.gradle file and adjusting the publishing configuration to align with the new Central Portal requirements.

## Why This Matters
As an authoritative project template for Kotlin Multiplatform (KMP) libraries, maintaining a reliable and up-to-date publishing process is critical. This project serves as a reference for the community, showcasing best practices for KMP library development and distribution. Ensuring compatibility with the latest Maven Central infrastructure keeps our template functional and relevant, allowing developers to confidently use it as a foundation for their own KMP projects.